### PR TITLE
Initial implementation of CryptContext wrapper.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.egg-info/
 .coverage
 .coverage.*
+.hypothesis/
 .tox/
+_trial_temp/

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,14 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],
     install_requires=[
+        'attrs>=16.0.0',
         'passlib>=1.7.0',
         'Twisted>=15.5.0',
         ],
+    extras_require={
+        'test': [
+            'testtools>=2.2.0',
+            'hypothesis>=3.6.0,<4.0.0',
+            ],
+        },
     )

--- a/src/txpasslib/__init__.py
+++ b/src/txpasslib/__init__.py
@@ -1,4 +1,3 @@
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/src/txpasslib/_threads.py
+++ b/src/txpasslib/_threads.py
@@ -14,9 +14,9 @@ def defer_to_worker(deliver, worker, work, *args, **kwargs):
             result = work(*args, **kwargs)
         except BaseException:
             f = Failure()
-            deliver(lambda: deferred.errback(f))
+            deliver(deferred.errback, f)
         else:
-            deliver(lambda: deferred.callback(result))
+            deliver(deferred.callback, result)
     worker.do(wrapped_work)
     return deferred
 

--- a/src/txpasslib/_threads.py
+++ b/src/txpasslib/_threads.py
@@ -1,0 +1,24 @@
+from twisted.internet.defer import Deferred
+from twisted.python.failure import Failure
+
+
+def defer_to_worker(deliver, worker, work, *args, **kwargs):
+    """
+    Run a task in a worker, delivering the result as a ``Deferred`` in the
+    reactor thread.
+    """
+    deferred = Deferred()
+
+    def wrapped_work():
+        try:
+            result = work(*args, **kwargs)
+        except BaseException:
+            f = Failure()
+            deliver(lambda: deferred.errback(f))
+        else:
+            deliver(lambda: deferred.callback(result))
+    worker.do(wrapped_work)
+    return deferred
+
+
+__init__ = ['defer_to_worker']

--- a/src/txpasslib/_threads.py
+++ b/src/txpasslib/_threads.py
@@ -21,4 +21,4 @@ def defer_to_worker(deliver, worker, work, *args, **kwargs):
     return deferred
 
 
-__init__ = ['defer_to_worker']
+__all__ = ['defer_to_worker']

--- a/src/txpasslib/context.py
+++ b/src/txpasslib/context.py
@@ -1,0 +1,44 @@
+"""
+Asynchronous wrappers for ``passlib.context``.
+"""
+import attr
+
+from txpasslib._threads import defer_to_worker
+
+
+@attr.s
+class TxCryptContext(object):
+    """
+    An asynchronous wrapper for ``CryptContext`` from ``passlib``.
+
+    Expensive operations are run in a thread pool to avoid blocking the main
+    thread.
+    """
+    _context = attr.ib()
+    _reactor = attr.ib()
+    _worker = attr.ib()
+
+    def _defer(self, f, *a, **kw):
+        return defer_to_worker(
+            self._reactor.callFromThread, self._worker,
+            f, *a, **kw)
+
+    def hash(self, secret, scheme=None, category=None, **kw):
+        """
+        Hash a secret.
+
+        See ``passlib.context.CryptContext.hash``.
+        """
+        return self._defer(self._context.hash, secret, scheme, category, **kw)
+
+    def verify(self, secret, hash, scheme=None, category=None, **kw):
+        """
+        Verify a secret against an existing hash.
+
+        See ``passlib.context.CryptContext.verify``.
+        """
+        return self._defer(
+            self._context.verify, secret, hash, scheme, category, **kw)
+
+
+__all__ = ['TxCryptContext']

--- a/src/txpasslib/test/doubles.py
+++ b/src/txpasslib/test/doubles.py
@@ -1,0 +1,18 @@
+"""
+Test doubles.
+"""
+from twisted.internet.interfaces import IReactorFromThreads
+from zope.interface import implementer
+
+
+@implementer(IReactorFromThreads)
+class SynchronousReactorThreads(object):
+    """
+    An implementation of ``IReactorFromThreads`` that calls things
+    synchronously in the same thread.
+    """
+    def callFromThread(self, f, *args, **kwargs):
+        f(*args, **kwargs)
+
+
+__all__ = ['SynchronousReactorThreads']

--- a/src/txpasslib/test/doubles.py
+++ b/src/txpasslib/test/doubles.py
@@ -11,7 +11,7 @@ class SynchronousReactorThreads(object):
     An implementation of ``IReactorFromThreads`` that calls things
     synchronously in the same thread.
     """
-    def callFromThread(self, f, *args, **kwargs):
+    def callFromThread(self, f, *args, **kwargs):  # noqa
         f(*args, **kwargs)
 
 

--- a/src/txpasslib/test/matchers.py
+++ b/src/txpasslib/test/matchers.py
@@ -1,0 +1,14 @@
+from operator import attrgetter
+
+from testtools.matchers import AfterPreprocessing
+from testtools.twistedsupport import failed
+
+
+def failed_with(matcher):
+    """
+    Match against the exception of a failure.
+    """
+    return failed(AfterPreprocessing(attrgetter('value'), matcher))
+
+
+__init__ = ['failed_with']

--- a/src/txpasslib/test/matchers.py
+++ b/src/txpasslib/test/matchers.py
@@ -11,4 +11,4 @@ def failed_with(matcher):
     return failed(AfterPreprocessing(attrgetter('value'), matcher))
 
 
-__init__ = ['failed_with']
+__all__ = ['failed_with']

--- a/src/txpasslib/test/matchers.py
+++ b/src/txpasslib/test/matchers.py
@@ -12,6 +12,9 @@ def failed_with(matcher):
 
 
 def performed(perform, matcher):
+    """
+    Match against a result after performing a single action in a memory worker.
+    """
     return MatchesAll(
         AfterPreprocessing(lambda _: perform(), Equals(True)),
         matcher)

--- a/src/txpasslib/test/matchers.py
+++ b/src/txpasslib/test/matchers.py
@@ -1,6 +1,6 @@
 from operator import attrgetter
 
-from testtools.matchers import AfterPreprocessing
+from testtools.matchers import AfterPreprocessing, Equals, MatchesAll
 from testtools.twistedsupport import failed
 
 
@@ -11,4 +11,10 @@ def failed_with(matcher):
     return failed(AfterPreprocessing(attrgetter('value'), matcher))
 
 
-__all__ = ['failed_with']
+def performed(perform, matcher):
+    return MatchesAll(
+        AfterPreprocessing(lambda _: perform(), Equals(True)),
+        matcher)
+
+
+__all__ = ['failed_with', 'performed']

--- a/src/txpasslib/test/test_context.py
+++ b/src/txpasslib/test/test_context.py
@@ -2,13 +2,14 @@ from hypothesis import strategies as s
 from hypothesis import given
 from passlib.context import CryptContext
 from testtools import TestCase
-from testtools.matchers import Always, Equals, IsInstance
+from testtools.matchers import (
+    AfterPreprocessing, Equals, IsInstance, MatchesAll)
 from testtools.twistedsupport import succeeded
 from twisted._threads import createMemoryWorker
 
 from txpasslib.context import TxCryptContext
 from txpasslib.test.doubles import SynchronousReactorThreads
-from txpasslib.test.matchers import failed_with
+from txpasslib.test.matchers import failed_with, performed
 
 
 class ContextTests(TestCase):
@@ -26,18 +27,18 @@ class ContextTests(TestCase):
         ctx = TxCryptContext(
             CryptContext(schemes=['plaintext']),
             reactor, worker)
-        d = ctx.hash(password)
-        perform()
-        self.assertThat(d, succeeded(Always()))
-        password_hash = d.result
-
-        d = ctx.verify(password, password_hash)
-        perform()
-        self.assertThat(d, succeeded(Equals(True)))
-
-        d = ctx.verify(password + u'junk', password_hash)
-        perform()
-        self.assertThat(d, succeeded(Equals(False)))
+        self.assertThat(
+            ctx.hash(password),
+            performed(
+                perform,
+                succeeded(
+                    MatchesAll(
+                        AfterPreprocessing(
+                            lambda h: ctx.verify(password, h),
+                            performed(perform, succeeded(Equals(True)))),
+                        AfterPreprocessing(
+                            lambda h: ctx.verify(password + u'junk', h),
+                            performed(perform, succeeded(Equals(False))))))))
 
     def test_verify_nonsense(self):
         """
@@ -48,9 +49,9 @@ class ContextTests(TestCase):
         ctx = TxCryptContext(
             CryptContext(schemes=['plaintext']),
             reactor, worker)
-        d = ctx.hash(42)
-        perform()
-        self.assertThat(d, failed_with(IsInstance(TypeError)))
+        self.assertThat(
+            ctx.hash(42),
+            performed(perform, failed_with(IsInstance(TypeError))))
 
 
 __all__ = ['ContextTests']

--- a/src/txpasslib/test/test_context.py
+++ b/src/txpasslib/test/test_context.py
@@ -53,4 +53,4 @@ class ContextTests(TestCase):
         self.assertThat(d, failed_with(IsInstance(TypeError)))
 
 
-__init__ = ['ContextTests']
+__all__ = ['ContextTests']

--- a/src/txpasslib/test/test_context.py
+++ b/src/txpasslib/test/test_context.py
@@ -1,0 +1,56 @@
+from hypothesis import strategies as s
+from hypothesis import given
+from passlib.context import CryptContext
+from testtools import TestCase
+from testtools.matchers import Always, Equals, IsInstance
+from testtools.twistedsupport import succeeded
+from twisted._threads import createMemoryWorker
+
+from txpasslib.context import TxCryptContext
+from txpasslib.test.doubles import SynchronousReactorThreads
+from txpasslib.test.matchers import failed_with
+
+
+class ContextTests(TestCase):
+    """
+    Tests for `txpasslib.context.CryptContext`.
+    """
+    @given(password=s.text())
+    def test_hash_and_verify(self, password):
+        """
+        Hashing a password fires with the hash; verifying the password against
+        that hash succeeds, while verifying a different password fails.
+        """
+        reactor = SynchronousReactorThreads()
+        worker, perform = createMemoryWorker()
+        ctx = TxCryptContext(
+            CryptContext(schemes=['plaintext']),
+            reactor, worker)
+        d = ctx.hash(password)
+        perform()
+        self.assertThat(d, succeeded(Always()))
+        password_hash = d.result
+
+        d = ctx.verify(password, password_hash)
+        perform()
+        self.assertThat(d, succeeded(Equals(True)))
+
+        d = ctx.verify(password + u'junk', password_hash)
+        perform()
+        self.assertThat(d, succeeded(Equals(False)))
+
+    def test_verify_nonsense(self):
+        """
+        Hashing a value of the wrong type fails with ``TypeError``.
+        """
+        reactor = SynchronousReactorThreads()
+        worker, perform = createMemoryWorker()
+        ctx = TxCryptContext(
+            CryptContext(schemes=['plaintext']),
+            reactor, worker)
+        d = ctx.hash(42)
+        perform()
+        self.assertThat(d, failed_with(IsInstance(TypeError)))
+
+
+__init__ = ['ContextTests']

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = coverage-clean,{py27,pypy,py34,py35}-{twlatest,twlowest,bleeding},flak
 setenv =
     PYTHONWARNINGS = default::DeprecationWarning
 deps =
+    .[test]
     twlatest: Twisted
     twlowest: Twisted==15.5.0
     bleeding: https://github.com/twisted/twisted/archive/trunk.zip#egg=Twisted


### PR DESCRIPTION
Fixes #1.

Putting this up for comment. One thing that should possibly be dealt with before landing this is creating a real thread pool; this should probably happen by default if you don't pass a worker at all, and there should also be a utility function to create a pool in case you want to share one between instances.